### PR TITLE
Deploy to heroku 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,8 @@
 source 'https://rubygems.org'
-
+ruby "2.2.4"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '>= 5.0.0.beta1', '< 5.1'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
@@ -28,6 +26,8 @@ gem 'puma'
 # gem 'capistrano-rails', group: :development
 
 group :development, :test do
+  # Use sqlite3 as the database for Active Record
+  gem 'sqlite3'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 end
@@ -35,6 +35,11 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 3.0'
+end
+
+group :production do
+  gem 'pg'
+  gem 'rails_12factor'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
+    pg (0.18.4)
     puma (2.15.3)
     rack (2.0.0.alpha)
       json
@@ -132,6 +133,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (5.0.0.beta1)
       actionpack (= 5.0.0.beta1)
       activesupport (= 5.0.0.beta1)
@@ -175,8 +181,10 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
+  pg
   puma
   rails (>= 5.0.0.beta1, < 5.1)
+  rails_12factor
   sqlite3
   turbolinks
   tzinfo-data
@@ -184,4 +192,4 @@ DEPENDENCIES
   web-console (~> 3.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ You should be able to chat like this:
 
 ![c7ERfXIREG.gif](https://qiita-image-store.s3.amazonaws.com/0/7465/b58e0bc4-eb80-3176-9baf-3009323c4485.gif "c7ERfXIREG.gif")
 
+### Deploy to Heroku
+
+```
+heroku create
+heroku addons:create heroku-redis
+git push heroku master
+heroku run rails db:migrate
+heroku open
+```
+
 ## License
 
 MIT License.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,6 +41,7 @@ Rails.application.configure do
   # Action Cable endpoint configuration
   # config.action_cable.url = 'wss://example.com/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  config.action_cable.allowed_request_origins = [ /https?:\/\/.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/redis/cable.yml
+++ b/config/redis/cable.yml
@@ -1,6 +1,6 @@
 # Action Cable uses Redis to administer connections, channels, and sending/receiving messages over the WebSocket.
 production:
-  url: redis://localhost:6379/1
+  url: <%= ENV['REDIS_URL'] || 'redis://localhost:6379/1' %>
 
 development:
   url: redis://localhost:6379/2


### PR DESCRIPTION
[リモートで動かない](http://ja.stackoverflow.com/q/20308/13807)のは、Action CableがWebSocketの接続元を制限しているからのようです。https://github.com/JunichiIto/campfire/commit/4b4e726f2b541d0f43ae019c6fc121df6f8fbc02 で接続元の制限をゆるくすることでチャットが実現できました (プロダクションに使うにはこの変更では制限がゆるすぎそうです)。

このプルリクエストには、上記のほかHerokuで動かすのに必要な変更と推奨される変更も含まれています。
